### PR TITLE
wrong selector for margin in message boxes

### DIFF
--- a/chatgpt.html
+++ b/chatgpt.html
@@ -436,9 +436,10 @@
       margin-left: 20px;
   }
   
-  .message p {
-      margin-bottom: 10px;
+  .message p + p {
+      margin-top: 10px;
   }
+  
   textarea {
       cursor: url('./image/cursor.png'), text !important;
   }


### PR DESCRIPTION
you have the following style snippet :
```css
.message p {
    margin-bottom: 10px;
}
```
This method "works" for messages that contains multiple `<p>` paragraphs, but it also adds a weird margin under each message content that isn't desired. To adress it, you can use the [next sibling operator](https://developer.mozilla.org/fr/docs/Web/CSS/Next-sibling_combinator)) to select only the `<p>` elements that are "directly followed" in the DOM by another paragraph. 

Before (margin below the user input message) :
![before](https://github.com/user-attachments/assets/b1f0be3a-819b-4fa3-88a1-3c987af78f1d)

After :
![after](https://github.com/user-attachments/assets/a53ed1d3-05da-447b-ad6b-b5f93b7c8d7a)